### PR TITLE
Fix overlay colors calculation

### DIFF
--- a/src/inspected-window-helpers/overlay-helpers.js
+++ b/src/inspected-window-helpers/overlay-helpers.js
@@ -130,7 +130,11 @@ export function setupOverlayHelpers() {
   }
 
   function getColorFromString(string, opacity = 0.4) {
-    const cleanStr = string.replace(/[^0-9a-z]/gi, "");
+    const cleanStr = string
+      .split("")
+      .map(l => (/[^0-9a-z]/gi.test(l) ? l.charCodeAt(0) : l)) // replace non-ascii with charCode integer
+      .join("");
+
     const raw = (
       parseInt(
         parseInt(cleanStr, 36)

--- a/src/inspected-window-helpers/overlay-helpers.js
+++ b/src/inspected-window-helpers/overlay-helpers.js
@@ -130,9 +130,10 @@ export function setupOverlayHelpers() {
   }
 
   function getColorFromString(string, opacity = 0.4) {
+    const cleanStr = string.replace(/[^0-9a-z]/gi, "");
     const raw = (
       parseInt(
-        parseInt(string, 36)
+        parseInt(cleanStr, 36)
           .toExponential()
           .slice(2, -5),
         10


### PR DESCRIPTION
Fix overlay colors calculation by removing non-alphanumeric characters that would cause parseInt to return NaN.

Resolves #44 

I tested this on the react.microfrontends.app site. 

<img width="1700" alt="Screen Shot 2020-04-16 at 5 08 16 PM" src="https://user-images.githubusercontent.com/4202993/79515076-eb0ddc00-8004-11ea-9f06-e1c86c59da47.png">
